### PR TITLE
Compatibility for AxeOS v2.2.2

### DIFF
--- a/json-exporter-config.yml
+++ b/json-exporter-config.yml
@@ -18,9 +18,13 @@ modules:
       type: value
       help: Current in mA
     - name: axe_fan_speed
-      path: "{.fanSpeed}"
+      path: "{.fanrpm}"
       type: value
       help: Fan speed in RPM
+    - name: axe_fan_speed_percent
+      path: "{.fanspeed}"
+      type: value
+      help: Fan speed in percentage
     - name: axe_temp
       path: "{.temp}"
       type: value


### PR DESCRIPTION
AxeOS release v2.2.2 broke the JSON parsing. This will fix it. Thanks for your great work!